### PR TITLE
Remove postinstall script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4-alpha - 8 November 2021
+### Fixed
+* Removes test-scenario postinstall script as it was preventing installation.
+
 ## 0.0.3-alpha - 8 November 2021
 ### Fixed
 * A handful of minor bugs relating to position logic (especially affecting hover).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
     "name": "@microsoft/compose-language-service",
-    "version": "0.0.3-alpha",
+    "version": "0.0.4-alpha",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/compose-language-service",
-            "version": "0.0.3-alpha",
-            "hasInstallScript": true,
+            "version": "0.0.4-alpha",
             "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "vscode-languageserver": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/compose-language-service",
     "author": "Microsoft Corporation",
-    "version": "0.0.3-alpha",
+    "version": "0.0.4-alpha",
     "publisher": "ms-azuretools",
     "description": "Language service for Docker Compose documents",
     "license": "See LICENSE in the project root for license information.",
@@ -24,8 +24,7 @@
         "test": "mocha --file lib/test/global.test.js lib/test/**/*.test.js",
         "unittest": "npm test -- --grep /unit/i",
         "pretest": "npm run build",
-        "prepack": "npm run build",
-        "postinstall": "cd ./src/test/clientExtension && npm install"
+        "prepack": "npm run build"
     },
     "devDependencies": {
         "@types/chai": "^4.2.14",


### PR DESCRIPTION
Removes the postinstall script. I didn't realize this would be called by installers of the language service, and it fails there.