### PR TITLE
Don't wrap lines

### DIFF
--- a/src/service/providers/DocumentFormattingProvider.ts
+++ b/src/service/providers/DocumentFormattingProvider.ts
@@ -20,6 +20,7 @@ export class DocumentFormattingProvider extends ProviderBase<DocumentFormattingP
             indentSeq: true,
             simpleKeys: true, // todo?
             nullStr: '',
+            lineWidth: 0,
         };
 
         const range = Range.create(

--- a/src/test/providers/DocumentFormattingProvider.test.ts
+++ b/src/test/providers/DocumentFormattingProvider.test.ts
@@ -45,6 +45,44 @@ services:
             await requestDocumentFormattingAndCompare(testConnection, uri, 2, expected2Space);
             await requestDocumentFormattingAndCompare(testConnection, uri, 4, expected4Space);
         });
+
+        it('Should NOT insert null on empty maps', async () => {
+            const testObject = `version: '123'
+services:
+  foo:
+    image: bar
+    build: .
+    ports:
+      - 1234
+
+volumes:
+  myvolume: \n`;
+
+            const uri = testConnection.sendTextAsYamlDocument(testObject);
+
+            const expected2Space = testObject; // Output will be unchanged, null must not be inserted
+
+            await requestDocumentFormattingAndCompare(testConnection, uri, 2, expected2Space);
+        });
+
+        it('Should NOT wrap long string lines', async () => {
+            const testObject = `version: '123'
+services:
+  foo:
+    image: bar
+    build: .
+    ports:
+      - 1234
+    labels:
+      - "com.microsoft.testlongstringlinesnowrapping=thequickbrownfoxjumpsoverthelazydog"
+`;
+
+            const uri = testConnection.sendTextAsYamlDocument(testObject);
+
+            const expected2Space = testObject; // Output will be unchanged, wrapping must not occur
+
+            await requestDocumentFormattingAndCompare(testConnection, uri, 2, expected2Space);
+        });
     });
 
     describe('Error scenarios', () => {


### PR DESCRIPTION
Fixes #70

The default behavior is to wrap string values that exceed a line width of 80. Setting this to 0 disables the wrapping: 

```typescript
    /**
     * Maximum line width (set to `0` to disable folding).
     *
     * This is a soft limit, as only double-quoted semantics allow for inserting
     * a line break in the middle of a word, as well as being influenced by the
     * `minContentWidth` option.
     *
     * Default: `80`
     */
    lineWidth?: number;
```

Incidentally while it says only double-quoted semantics allow this, I saw that it was still splitting strings that had single or no quotes.