### PR TITLE
Mocha not discovering tests properly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
                 "0",
                 "--file",
                 "${workspaceFolder}/lib/test/global.test.js",
-                "${workspaceFolder}/lib/test/**/*.test.js"
+                "--recursive",
+                "${workspaceFolder}/lib/test"
             ],
             "preLaunchTask": "${defaultBuildTask}",
             "resolveSourceMapLocations": [
@@ -38,7 +39,8 @@
                 "${workspaceFolder}/lib/test/global.test.js",
                 "--grep",
                 "/unit/i",
-                "${workspaceFolder}/lib/test/**/*.test.js"
+                "--recursive",
+                "${workspaceFolder}/lib/test"
             ],
             "preLaunchTask": "${defaultBuildTask}",
             "resolveSourceMapLocations": [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "scripts": {
         "build": "tsc",
         "lint": "eslint --max-warnings 0 src --ext ts",
-        "test": "mocha --file lib/test/global.test.js lib/test/**/*.test.js",
+        "test": "mocha --file lib/test/global.test.js --recursive lib/test",
         "unittest": "npm test -- --grep /unit/i",
         "pretest": "npm run build",
         "prepack": "npm run build"


### PR DESCRIPTION
I noticed on that on Linux builds, Mocha was not properly discovering tests, and was skipping a ton of them as a result which is not good. Changing the match here gets it to run all the tests on both Linux and Windows.