### PR TITLE
Allow merge keys

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,6 +59,7 @@
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}/src/test/clientExtension",
                 "--disable-extension=ms-azuretools.vscode-docker", // Keep the Docker extension from running so it doesn't interfere with testing
+                "--disable-extension=redhat.vscode-yaml", // Keep the YAML extension from running so it doesn't interfere with testing
             ],
             "preLaunchTask": "tsc-watch: client extension",
             "presentation": {

--- a/src/service/ComposeDocument.ts
+++ b/src/service/ComposeDocument.ts
@@ -169,7 +169,7 @@ export class ComposeDocument {
     }
 
     private buildYamlDocument(): YamlDocument {
-        const composedTokens = new Composer().compose(this.fullCst.value, true);
+        const composedTokens = new Composer({ merge: true }).compose(this.fullCst.value, true);
         const [yamlDocument] = composedTokens;
 
         if (!isDocument(yamlDocument)) {


### PR DESCRIPTION
Fixes #78. Merge keys will be allowed, e.g.
```yaml
version: '3.8'

x-foo: &foo
  FOO: FOO

x-bar: &bar
  BAR: BAR

services:
  foo-bar:
    image: alpine
    environment:
      <<: *foo
      <<: *bar
    entrypoint: sh
```

Note that it will _not_ flag the `FOO: override` line below:
```yaml
version: '3.8'

x-foo: &foo
  FOO: FOO

x-bar: &bar
  BAR: BAR

services:
  foo-bar:
    image: alpine
    environment:
      <<: *foo
      <<: *bar
      FOO: override # Technically a duplicate key; though compose will override the above `FOO` with this value
    entrypoint: sh
```