### PR TITLE
Update `yaml` and minor enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "vscode-languageserver": "^7.0.0",
                 "vscode-languageserver-textdocument": "^1.0.3",
-                "yaml": "^2.0.0-9"
+                "yaml": "^2.0.0-10"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.0",
@@ -2156,9 +2156,9 @@
             "dev": true
         },
         "node_modules/yaml": {
-            "version": "2.0.0-9",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-9.tgz",
-            "integrity": "sha512-Bf2KowHjyVkIIiGMt7+fbhmlvKOaE8DWuD07bnL4+FQ9sPmEl/5IzGpBpoxPqOaHuyasBjJhyXDcISpJWfhCGw==",
+            "version": "2.0.0-10",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-10.tgz",
+            "integrity": "sha512-FHV8s5ODFFQXX/enJEU2EkanNl1UDBUz8oa4k5Qo/sR+Iq7VmhCDkRMb0/mjJCNeAWQ31W8WV6PYStDE4d9EIw==",
             "engines": {
                 "node": ">= 12"
             }
@@ -3738,9 +3738,9 @@
             "dev": true
         },
         "yaml": {
-            "version": "2.0.0-9",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-9.tgz",
-            "integrity": "sha512-Bf2KowHjyVkIIiGMt7+fbhmlvKOaE8DWuD07bnL4+FQ9sPmEl/5IzGpBpoxPqOaHuyasBjJhyXDcISpJWfhCGw=="
+            "version": "2.0.0-10",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-10.tgz",
+            "integrity": "sha512-FHV8s5ODFFQXX/enJEU2EkanNl1UDBUz8oa4k5Qo/sR+Iq7VmhCDkRMb0/mjJCNeAWQ31W8WV6PYStDE4d9EIw=="
         },
         "yargs": {
             "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "dependencies": {
         "vscode-languageserver": "^7.0.0",
         "vscode-languageserver-textdocument": "^1.0.3",
-        "yaml": "^2.0.0-9"
+        "yaml": "^2.0.0-10"
     }
 }

--- a/src/test/providers/DiagnosticProvider.test.ts
+++ b/src/test/providers/DiagnosticProvider.test.ts
@@ -68,7 +68,7 @@ services:
                 },
                 {
                     range: Range.create(8, 0, 8, 0),
-                    contentCanary: 'sequence to end with ]',
+                    contentCanary: 'and end with a ]',
                 },
             ];
 


### PR DESCRIPTION
A couple of things in this PR:

1. Update to `yaml` package
1. I added the `prettyErrors: true` parameter to our doc parser. It's true by default, but it is _essential_ to the user experience, so I wanted to have it explicitly passed so that if it ever became false by default things would still work, and if it were removed it would result in a compilation error.
1. I noticed better error messages (more detail) if we directly parsed the document, rather than going from Tokenizer -> Composer. We weren't using the CST anymore anyway. For example, before and after:
![image](https://user-images.githubusercontent.com/36966225/151375971-719e783e-671c-4e84-8cb6-7c36aa1a4618.png)
![image](https://user-images.githubusercontent.com/36966225/151376089-e0b809f3-e8ef-4f3f-96d1-82d84066eba2.png)
1. Fix a UT failure that arose from slightly different error messages due to change 3 above