### PR TITLE
Update version, changelog, notices for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0 - 14 February 2022
+### Fixed
+* Merge keys are now allowed. [#78](https://github.com/microsoft/compose-language-service/issues/78)
+* Better error messages. [#88](https://github.com/microsoft/compose-language-service/pull/88)
+
 ## 0.0.5-alpha - 15 December 2021
 ### Added
 * Completions under the `build` section within a service. [#48](https://github.com/microsoft/compose-language-service/issues/48)

--- a/NOTICE.html
+++ b/NOTICE.html
@@ -143,10 +143,11 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 <li>
     <details>
         <summary>
-            yaml 2.0.0-8 - ISC
+            yaml 2.0.0-10 - ISC
         </summary>
         <p><a href="https://eemeli.org/yaml/">https://eemeli.org/yaml/</a></p>
-        
+        <ul><li>Copyright (c) Microsoft Corporation.</li>
+<li>Copyright Eemeli Aro &lt;eemeli@gmail.com&gt;</li></ul>
         <pre>
         Copyright Eemeli Aro &lt;eemeli@gmail.com&gt;
 
@@ -358,7 +359,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 <li>
     <details>
         <summary>
-            vscode-languageserver-textdocument 1.0.2 - MIT
+            vscode-languageserver-textdocument 1.0.3 - MIT
         </summary>
         <p><a href="https://github.com/Microsoft/vscode-languageserver-node#readme">https://github.com/Microsoft/vscode-languageserver-node#readme</a></p>
         <ul><li>Copyright (c) Microsoft Corporation.</li></ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/compose-language-service",
-    "version": "0.0.6-alpha",
+    "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/compose-language-service",
-            "version": "0.0.6-alpha",
+            "version": "0.1.0",
             "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "vscode-languageserver": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/compose-language-service",
     "author": "Microsoft Corporation",
-    "version": "0.0.6-alpha",
+    "version": "0.1.0",
     "publisher": "ms-azuretools",
     "description": "Language service for Docker Compose documents",
     "license": "See LICENSE in the project root for license information.",


### PR DESCRIPTION
Removes `-alpha` from the version number since we don't really need that anymore.

Additionally, I'm going to bump the version number to `0.1.0`. We use caret notation for dependencies basically everywhere, which treats the left-most non-zero version number like it is a major version. Thus, if we updated this package from `0.0.5` to `0.0.6`, `npm update` would _not_ pick it up.

For non-breaking changes, I want to make sure `npm update` _does_ pick them up.