### PR TITLE
Support `!reset` and `!override` tags for compose

### DIFF
--- a/src/service/ComposeDocument.ts
+++ b/src/service/ComposeDocument.ts
@@ -5,7 +5,7 @@
 
 import { ErrorCodes, Position, Range, ResponseError, TextDocumentIdentifier, TextDocumentsConfiguration } from 'vscode-languageserver';
 import { DocumentUri, TextDocument } from 'vscode-languageserver-textdocument';
-import { Document as YamlDocument, isDocument, Node as YamlNode, parseDocument } from 'yaml';
+import { Document as YamlDocument, isDocument, Node as YamlNode, parseDocument, ScalarTag, Tags } from 'yaml';
 import { CRLF, DocumentSettings, DocumentSettingsParams, DocumentSettingsRequest, LF } from '../client/DocumentSettings';
 import { ExtendedPositionParams, PositionInfo } from './ExtendedParams';
 import { getCurrentContext } from './utils/ActionContext';
@@ -152,7 +152,7 @@ export class ComposeDocument {
     };
 
     private buildYamlDocument(): YamlDocument<YamlNode> {
-        const yamlDocument = parseDocument(this.textDocument.getText(), { merge: true, prettyErrors: true });
+        const yamlDocument = parseDocument(this.textDocument.getText(), { merge: true, prettyErrors: true, customTags: ComposeCustomTags });
 
         if (!isDocument(yamlDocument)) {
             throw new ResponseError(ErrorCodes.ParseError, 'Malformed YAML document');
@@ -346,3 +346,13 @@ const Value = '<value>';
 const Item = '<item>';
 const Sep = '<sep>';
 const Comment = '<comment>';
+
+// Custom YAML tags that Compose supports
+const ComposeCustomTags: Tags = [
+    { tag: '!reset', collection: 'seq', resolve: v => v },
+    { tag: '!reset', collection: 'map', resolve: v => v },
+    { tag: '!reset', resolve: v => v} satisfies ScalarTag,
+    { tag: '!override', collection: 'seq', resolve: v => v },
+    { tag: '!override', collection: 'map', resolve: v => v },
+    { tag: '!override', resolve: v => v} satisfies ScalarTag,
+];

--- a/src/test/providers/DiagnosticProvider.test.ts
+++ b/src/test/providers/DiagnosticProvider.test.ts
@@ -107,6 +107,46 @@ services:
         });
     });
 
+    describe('Custom Tags', async () => {
+        it('Should provide nothing for valid compose documents with known custom tags', async () => {
+            const validComposeWithTags = `version: '123'
+
+services:
+  foo:
+    image: !reset bar
+    ports: !override
+      - 1234
+    environment: !override
+      foo: bar
+`;
+
+            const expected = undefined;
+            await awaitDiagnosticsAndCompare(testConnection, validComposeWithTags, expected);
+        });
+
+        it('Should provide something for valid compose documents with unknown custom tags', async () => {
+            const validComposeWithUnknownTags = `version: '123'
+
+services:
+  foo:
+    image: bar
+    ports:
+      - 1234
+    environment: !unknowntag
+      foo: bar
+`;
+
+            const expected: ExpectedDiagnostic[] = [
+                {
+                    range: Range.create(7, 17, 7, 28),
+                    contentCanary: 'Unresolved tag',
+                }
+            ];
+
+            await awaitDiagnosticsAndCompare(testConnection, validComposeWithUnknownTags, expected);
+        });
+    });
+
     after('Cleanup', () => {
         testConnection.dispose();
         noDiagnosticsTestConnection.dispose();


### PR DESCRIPTION
Fixes #145 