### PR TITLE
Explicitly set license in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
         "": {
             "name": "@microsoft/compose-language-service",
             "version": "0.3.0",
-            "license": "See LICENSE in the project root for license information.",
+            "license": "MIT",
             "dependencies": {
                 "vscode-languageserver": "^8.0.2",
                 "vscode-languageserver-textdocument": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "0.3.0",
     "publisher": "ms-azuretools",
     "description": "Language service for Docker Compose documents",
-    "license": "See LICENSE in the project root for license information.",
+    "license": "MIT",
     "repository": {
         "type": "git",
         "url": "https://github.com/microsoft/compose-language-service"


### PR DESCRIPTION
Fixes #165. I have confirmed that other first-party extensions and packages use the same format so it should be OK.

Example from Python extension: https://github.com/microsoft/vscode-python/blob/4b7650e0428b0107ba499835754eb5908d0017bd/package.json#L34

Example from `@vscode/extension-telemetry`: https://github.com/microsoft/vscode-extension-telemetry/blob/56c35efa23d13255dbe7dbb636213e9ccdace90d/package.json#L12