### PR TITLE
Phase C: remove redundant npmFeed parameter

### DIFF
--- a/.config/build.yml
+++ b/.config/build.yml
@@ -34,5 +34,4 @@ extends:
   template: azdo-pipelines/1es-mb-main.yml@azExtTemplates # Use the main build template
   parameters:
     signType: none
-    npmFeed: ${{ variables.npmFeed }}
     feedBaseUrl: ${{ variables.feedBaseUrl }}


### PR DESCRIPTION
## Phase C -- remove the `npmFeed` parameter

Removes the now-redundant `npmFeed: ${{ variables.npmFeed }}` line from the `extends.parameters` block in `.config/build.yml`. Keeps `feedBaseUrl`, which is the canonical private-feed mechanism now that `azext-pt/v1` runs the fail-closed template (microsoft/vscode-azuretools#2319).

This is a **no-op under the live template** -- `npmFeed` is already an ignored, no-op parameter on `v1`, so removing it does not change build behavior. Private-feed auth continues to be driven entirely by `feedBaseUrl`.

The `npmFeed` **variable** in `azcode.variables.yml` is intentionally left in place (any repo-local `additionalSetupSteps` that reference `${{ variables.npmFeed }}` keep working).

Part of the npm feed migration tracked in microsoft/vscode-azuretools#2320 (Phase C).
