### PR TITLE
Pass feedBaseUrl to NPM release template for internal feed publish

### DIFF
--- a/.config/release.yml
+++ b/.config/release.yml
@@ -48,3 +48,4 @@ extends:
     approverAliases: ${{ variables.npmReleaseApproverAliases }}
     gitHubServiceConnection: ${{ variables.gitHubServiceConnection }}
     releaseApprovalEnvironment: VSCodeDockerExtensionPublish
+    feedBaseUrl: ${{ variables.feedBaseUrl }}


### PR DESCRIPTION
Adds the `feedBaseUrl: ${{ variables.feedBaseUrl }}` parameter to the `extends.parameters` block in `.config/release.yml` (right after `releaseApprovalEnvironment:`). This passes the internal feed base URL to the NPM release template so it also publishes the released tarball to the internal Azure Artifacts feed after the ESRP publish to npmjs.org.

`feedBaseUrl` is already provided by the shared `azdo-pipelines/azcode.variables.yml@azExtTemplates` template imported here, so no other change is needed.

:warning: **Must stay a DRAFT until the vscode-azuretools template change is released to `azext-pt/v1`.** This repo consumes the template at `ref: azext-pt/v1`, which does not yet have the `feedBaseUrl` parameter (the template change is an unmerged/unreleased PR in microsoft/vscode-azuretools). Merging before the template is released would cause the pipeline to fail to compile on the unknown parameter.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>