### PR TITLE
Keep Compose image links local when Docker is present

### DIFF
--- a/src/vscode/AlternateYamlLanguageServiceClientFeature.ts
+++ b/src/vscode/AlternateYamlLanguageServiceClientFeature.ts
@@ -33,7 +33,7 @@ export class AlternateYamlLanguageServiceClientFeature implements StaticFeature,
                 basicCompletions: redhat || docker,
                 advancedCompletions: false, // The other extensions do not have advanced completions for Compose docs
                 hover: redhat || docker, // Compose spec has descriptions
-                imageLinks: docker, // Docker's extension supports Docker Hub, GHCR, MAR, and Quay.io
+                imageLinks: false, // Keep Compose image links local so private registries aren't treated as Docker Hub images
                 serviceStartupCodeLens: false, // The other extensions do not provide any code lens
                 formatting: false, // The other extensions do support formatting, but we enable it regardless so that an explicitly-chosen formatter always works
             };


### PR DESCRIPTION
Fixes #179.

When the Docker extension is present, this client capability currently tells the Compose language service to stop providing image links. That hands image refs to Docker's provider, which can turn private registry refs into Docker Hub URLs.

This keeps Compose's own image link provider active so it keeps using the stricter registry handling already in this package.

Checked with `git diff --check` using the repo's CRLF-aware whitespace settings. I did not run the mocha suite locally because this fresh checkout does not have the Node dependencies installed.
